### PR TITLE
retrait de php5-mysqlnd au profit de php5-mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 MAINTAINER Prytoegrian <prytoegrian@protonmail.com>
 
-RUN apt-get update && apt-get install -y mysql-client mysql-server vim apache2 libapache2-mod-php5 language-pack-fr php5 php5-mysqlnd php5-dev php5-xdebug
+RUN apt-get update && apt-get install -y mysql-client mysql-server vim apache2 libapache2-mod-php5 language-pack-fr php5 php5-mysql php5-dev php5-xdebug
 RUN a2enmod rewrite
 
 COPY ./config/apache/sites/* /etc/apache2/sites-available/


### PR DESCRIPTION
étant donné que https://github.com/Libertempo/Libertempo-web/pull/358 permet de ne plus etre dépendant de php5-mysqlnd, le retrait de cette lib dans le docker cool de source...